### PR TITLE
Alert config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ To do this, you can update it using Push Notification on a server.
 | ```.init()``` | Initialize the Plugin by providing an App Group Id (see above)  | ```Future``` When the plugin is ready to create/update an activity |
 | ```.createActivity()``` | Create an iOS live activity  | ```String``` The activity identifier |
 | ```.updateActivity()``` | Update the live activity data by using the ```activityId``` provided  | ```Future``` When the activity was updated |
+| ```.updateActivityWithAlert()``` | Update the live activity data with an alert by using the ```activityId``` provided, and an ```alertTitle``` and ```alertBody```  | ```Future``` When the activity was updated |
 | ```.endActivity()``` | End the live activity by using the ```activityId``` provided | ```Future``` When the activity was ended |
 | ```.getAllActivitiesIds()``` | Get all activities ids created | ```Future<List<String>>``` List of all activities ids |
 | ```.endAllActivities()``` | End all live activities of the app | ```Future``` When all activities was ended |

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -142,10 +142,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -158,18 +158,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -320,5 +320,5 @@ packages:
     source: hosted
     version: "0.2.0+2"
 sdks:
-  dart: ">=2.18.1 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=3.0.0"

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -114,7 +114,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
             result(FlutterError(code: "WRONG_ARGS", message: "Unknown data type in argument", details: nil))
             return
           }
-          let sound = args["sound"] as String
+          let sound = args["sound"] as? String
           updateActivityWithAlert(activityId: activityId, data: data, title: title, body: body, sound: sound, result: result)
           break
         case "endActivity":
@@ -233,6 +233,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       result(nil)
     }
   }
+  
   // @available(iOS 16.1, *)
   // func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
   //   Task {
@@ -271,13 +272,16 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
                   
                   let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
                   let alertSound: AlertConfiguration.AlertSound
+
+                  let titleResource = LocalizedStringResource.init(stringLiteral: title)
+                  let bodyResource = LocalizedStringResource.init(stringLiteral: body)
                   switch sound {
                   case "default":
                       alertSound = .default
                   default:
                       alertSound = .default
                   }
-                  let alertConfig = AlertConfiguration(title: title, body: body, sound: alertSound)
+                  let alertConfig = AlertConfiguration(title: titleResource, body: bodyResource, sound: alertSound)
                   await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
                   break;
               }

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -234,28 +234,6 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  // @available(iOS 16.1, *)
-  // func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
-  //   Task {
-  //     for activity in Activity<LiveActivitiesAppAttributes>.activities {
-  //       if activityId == activity.id {
-  //         for item in data {
-  //           if (item.value != nil && !(item.value is NSNull)) {
-  //             sharedDefault!.set(item.value, forKey: item.key)
-  //           } else {
-  //             sharedDefault!.removeObject(forKey: item.key)
-  //           }
-  //         }
-          
-  //         let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
-  //         let alertConfig = AlertConfiguration(title: "This is a title", body: "Default Body", sound: .default)
-  //         await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
-  //         break;
-  //       }
-  //     }
-  //     result(nil)
-  //   }
-  // }
 
  @available(iOS 16.1, *)
   func updateActivityWithAlert(activityId: String, data: [String: Any?], title: String, body: String, sound: String?, result: @escaping FlutterResult) {
@@ -275,6 +253,7 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
 
                   let titleResource = LocalizedStringResource.init(stringLiteral: title)
                   let bodyResource = LocalizedStringResource.init(stringLiteral: body)
+                  // todo: accept different sounds files
                   switch sound {
                   case "default":
                       alertSound = .default

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -199,6 +199,27 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
+  // @available(iOS 16.1, *)
+  // func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
+  //   Task {
+  //     for activity in Activity<LiveActivitiesAppAttributes>.activities {
+  //       if activityId == activity.id {
+  //         for item in data {
+  //           if (item.value != nil && !(item.value is NSNull)) {
+  //             sharedDefault!.set(item.value, forKey: item.key)
+  //           } else {
+  //             sharedDefault!.removeObject(forKey: item.key)
+  //           }
+  //         }
+          
+  //         let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
+  //         await activity.update(using: updatedStatus, alertConfiguration: nil)
+  //         break;
+  //       }
+  //     }
+  //     result(nil)
+  //   }
+  // }
   @available(iOS 16.1, *)
   func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
     Task {
@@ -213,13 +234,15 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
           }
           
           let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
-          await activity.update(using: updatedStatus)
+          let alertConfig = AlertConfiguration(title: "This is a title", body: "Default Body", sound: .default)
+          await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
           break;
         }
       }
       result(nil)
     }
   }
+
   
   @available(iOS 16.1, *)
   func getActivityState(activityId: String, result: @escaping FlutterResult) {

--- a/ios/Classes/SwiftLiveActivitiesPlugin.swift
+++ b/ios/Classes/SwiftLiveActivitiesPlugin.swift
@@ -104,6 +104,19 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
             result(FlutterError(code: "WRONG_ARGS", message: "argument are not valid, check if 'activityId' & 'data' are valid", details: nil))
           }
           break
+        case "updateActivityWithAlert":
+          initializationGuard(result: result)
+          guard let args = call.arguments as? [String: Any],
+                let activityId = args["activityId"] as? String,
+                let data = args["data"] as? [String: Any],
+                let title = args["title"] as? String,
+                let body = args["body"] as? String else {
+            result(FlutterError(code: "WRONG_ARGS", message: "Unknown data type in argument", details: nil))
+            return
+          }
+          let sound = args["sound"] as String
+          updateActivityWithAlert(activityId: activityId, data: data, title: title, body: body, sound: sound, result: result)
+          break
         case "endActivity":
           guard let args = call.arguments as? [String: Any] else {
             result(FlutterError(code: "WRONG_ARGS", message: "Unknown data type in argument", details: nil))
@@ -199,27 +212,6 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
   }
   
-  // @available(iOS 16.1, *)
-  // func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
-  //   Task {
-  //     for activity in Activity<LiveActivitiesAppAttributes>.activities {
-  //       if activityId == activity.id {
-  //         for item in data {
-  //           if (item.value != nil && !(item.value is NSNull)) {
-  //             sharedDefault!.set(item.value, forKey: item.key)
-  //           } else {
-  //             sharedDefault!.removeObject(forKey: item.key)
-  //           }
-  //         }
-          
-  //         let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
-  //         await activity.update(using: updatedStatus, alertConfiguration: nil)
-  //         break;
-  //       }
-  //     }
-  //     result(nil)
-  //   }
-  // }
   @available(iOS 16.1, *)
   func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
     Task {
@@ -234,14 +226,66 @@ public class SwiftLiveActivitiesPlugin: NSObject, FlutterPlugin, FlutterStreamHa
           }
           
           let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
-          let alertConfig = AlertConfiguration(title: "This is a title", body: "Default Body", sound: .default)
-          await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
+          await activity.update(using: updatedStatus, alertConfiguration: nil)
           break;
         }
       }
       result(nil)
     }
   }
+  // @available(iOS 16.1, *)
+  // func updateActivity(activityId: String, data: [String: Any?], result: @escaping FlutterResult) {
+  //   Task {
+  //     for activity in Activity<LiveActivitiesAppAttributes>.activities {
+  //       if activityId == activity.id {
+  //         for item in data {
+  //           if (item.value != nil && !(item.value is NSNull)) {
+  //             sharedDefault!.set(item.value, forKey: item.key)
+  //           } else {
+  //             sharedDefault!.removeObject(forKey: item.key)
+  //           }
+  //         }
+          
+  //         let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
+  //         let alertConfig = AlertConfiguration(title: "This is a title", body: "Default Body", sound: .default)
+  //         await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
+  //         break;
+  //       }
+  //     }
+  //     result(nil)
+  //   }
+  // }
+
+ @available(iOS 16.1, *)
+  func updateActivityWithAlert(activityId: String, data: [String: Any?], title: String, body: String, sound: String?, result: @escaping FlutterResult) {
+      Task {
+          for activity in Activity<LiveActivitiesAppAttributes>.activities {
+              if activityId == activity.id {
+                  for item in data {
+                      if let value = item.value as? String, !(item.value is NSNull) {
+                          sharedDefault!.set(value, forKey: item.key)
+                      } else {
+                          sharedDefault!.removeObject(forKey: item.key)
+                      }
+                  }
+                  
+                  let updatedStatus = LiveActivitiesAppAttributes.LiveDeliveryData(appGroupId: self.appGroupId!)
+                  let alertSound: AlertConfiguration.AlertSound
+                  switch sound {
+                  case "default":
+                      alertSound = .default
+                  default:
+                      alertSound = .default
+                  }
+                  let alertConfig = AlertConfiguration(title: title, body: body, sound: alertSound)
+                  await activity.update(using: updatedStatus, alertConfiguration: alertConfig)
+                  break;
+              }
+          }
+          result(nil)
+      }
+  }
+
 
   
   @available(iOS 16.1, *)

--- a/lib/live_activities.dart
+++ b/lib/live_activities.dart
@@ -46,6 +46,12 @@ class LiveActivities {
     return LiveActivitiesPlatform.instance.updateActivity(activityId, data);
   }
 
+  // Update activity with alert to bring to banner  
+  Future updateActivityWithAlert(String activityId, Map<String, dynamic> data, String title, String body, {String? sound}) {
+    return LiveActivitiesPlatform.instance.updateActivityWithAlert(activityId, data, title, body, sound: sound);
+  }
+
+
   /// End an iOS 16.1+ live activity.
   /// You can get an activity id by calling [createActivity].
   Future endActivity(String activityId) {

--- a/lib/live_activities_method_channel.dart
+++ b/lib/live_activities_method_channel.dart
@@ -53,6 +53,18 @@ class MethodChannelLiveActivities extends LiveActivitiesPlatform {
       'data': data,
     });
   }
+  
+  @override
+  Future updateActivityWithAlert(String activityId, Map<String, dynamic> data, String title, String body, {String? sound}) {
+    return methodChannel.invokeMethod('updateActivityWithAlert', {
+      'activityId': activityId,
+      'data': data,
+      'title': title,
+      'body': body,
+      'sound': sound,
+    });
+  }
+
 
   @override
   Future endActivity(String activityId) async {

--- a/lib/live_activities_platform_interface.dart
+++ b/lib/live_activities_platform_interface.dart
@@ -42,6 +42,11 @@ abstract class LiveActivitiesPlatform extends PlatformInterface {
     throw UnimplementedError('updateActivity() has not been implemented.');
   }
 
+  Future updateActivityWithAlert(String activityId, Map<String, dynamic> data, String title, String body, {String? sound}) {
+    throw UnimplementedError('updateActivityWithAlert() has not been implemented.');
+  }
+
+
   Future endActivity(String activityId) {
     throw UnimplementedError('endActivity() has not been implemented.');
   }


### PR DESCRIPTION
Add a new method, `UpdateActivityWithAlert` that adds a title and a body to trigger an alert.

https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities
>  On an unlocked device that doesn’t support the Dynamic Island, the Lock Screen presentation also appears as a banner for Live Activity updates that include an alert configuration. For example, if a person uses Mail on a device that doesn’t support the Dynamic Island while the Live Activity receives an update with an alert configuration, the system displays the Lock Screen presentation as a banner at the top of the screen to let them know about the updated Live Activity.

Remaining todo: accept other sound files